### PR TITLE
Make ImplicitDataset consume less memory when building index

### DIFF
--- a/openrec/implicit_model_trainer.py
+++ b/openrec/implicit_model_trainer.py
@@ -129,7 +129,7 @@ class ImplicitModelTrainer(object):
             scores = self._score_full_items(users=users)
             for u_ind, user in enumerate(users):
                 result = self._eval_manager.full_eval(
-                                    pos_samples=list(eval_dataset.get_interactions_by_user_gb_item(user).keys()),
+                                    pos_samples=eval_dataset.get_interactions_by_user_gb_item(user),
                                     excl_pos_samples=self._excluded_positives[user],
                                     predictions=scores[u_ind])
                 for key in result:
@@ -144,7 +144,7 @@ class ImplicitModelTrainer(object):
             metric_results[evaluator.name] = []
 
         for user in tqdm(eval_dataset.get_unique_user_list()):
-            items = self._sampled_negatives[user] + list(eval_dataset.get_interactions_by_user_gb_item(user).keys())
+            items = self._sampled_negatives[user] + eval_dataset.get_interactions_by_user_gb_item(user)
             scores = self._score_partial_items(user, items)
             result = self._eval_manager.partial_eval(pos_scores=scores[self._num_negatives:], neg_scores=scores[:self._num_negatives])
             for key in result:
@@ -163,10 +163,10 @@ class ImplicitModelTrainer(object):
             self._excluded_positives[user] = set()
         for user in user_set:
             if self._train_dataset.contain_user(user):
-                self._excluded_positives[user] = self._excluded_positives[user].union(list(self._train_dataset.get_interactions_by_user_gb_item(user).keys()))
+                self._excluded_positives[user] = self._excluded_positives[user].union(self._train_dataset.get_interactions_by_user_gb_item(user))
             for dataset in eval_datasets:
                 if dataset.contain_user(user):
-                    self._excluded_positives[user] = self._excluded_positives[user].union(list(dataset.get_interactions_by_user_gb_item(user).keys()))
+                    self._excluded_positives[user] = self._excluded_positives[user].union(dataset.get_interactions_by_user_gb_item(user))
 
 
     def _sample_negatives(self):

--- a/openrec/utils/dataset.py
+++ b/openrec/utils/dataset.py
@@ -38,6 +38,7 @@ class Dataset(object):
         else:
             raise TypeError("Unsupported data input schema. Please use structured numpy array.")
         
+        self.data = None
         self._max_user = max_user
         self._max_item = max_item
     

--- a/openrec/utils/implicit_dataset.py
+++ b/openrec/utils/implicit_dataset.py
@@ -38,25 +38,19 @@ class ImplicitDataset(Dataset):
                                               max_item=max_item, name=name)
 
         self._gb_user_item = dict()
-        for ind, entry in enumerate(self.raw_data):
+        for entry in self.raw_data:
             if entry['user_id'] not in self._gb_user_item:
-                self._gb_user_item[entry['user_id']] = dict()
-            if entry['item_id'] not in self._gb_user_item[entry['user_id']]:
-                self._gb_user_item[entry['user_id']][entry['item_id']] = []
-            self._gb_user_item[entry['user_id']][entry['item_id']].append(ind)
-
+                self._gb_user_item[entry['user_id']] = list()
+            self._gb_user_item[entry['user_id']].append(entry['item_id'])
+        
         self._gb_item_user = dict()
-        for ind, entry in enumerate(self.raw_data):
+        for entry in self.raw_data:
             if entry['item_id'] not in self._gb_item_user:
-                self._gb_item_user[entry['item_id']] = dict()
-            if entry['user_id'] not in self._gb_item_user[entry['item_id']]:
-                self._gb_item_user[entry['item_id']][entry['user_id']] = []
-            self._gb_item_user[entry['item_id']][entry['user_id']].append(ind)
-
-        self._users = np.array(list(self._gb_user_item.keys()))
-        self._items = np.array(list(self._gb_item_user.keys()))
-        self._num_user = len(self._users)
-        self._num_item = len(self._items)
+                self._gb_item_user[entry['item_id']] = list()
+            self._gb_item_user[entry['item_id']].append(entry['user_id'])
+        
+        self._num_user = len(self._gb_user_item)
+        self._num_item = len(self._gb_item_user)
 
     def contain_user(self, user_id):
         """Check whether or not an user is involved in any interaction.
@@ -98,8 +92,8 @@ class ImplicitDataset(Dataset):
 
         Returns
         -------
-        dict
-            Interactions grouped by item ids.
+        list
+            Items that have interacted with given user.
         """
         return self._gb_user_item[user_id]
 
@@ -113,8 +107,8 @@ class ImplicitDataset(Dataset):
 
         Returns
         -------
-        dict
-            Interactions grouped by user ids.
+        list
+            Users that have interacted with given item.
         """
         return self._gb_item_user[item_id]
 
@@ -126,7 +120,7 @@ class ImplicitDataset(Dataset):
         numpy array
             A list of unique user ids.
         """
-        return self._users
+        return np.array(self._gb_user_item.keys())
 
     def get_unique_item_list(self):
         """Retrieve a list of unique item ids.
@@ -136,7 +130,7 @@ class ImplicitDataset(Dataset):
         numpy array
             A list of unique item ids.
         """
-        return self._items
+        return np.array(self._gb_item_user.keys())
 
     def unique_user_count(self):
         """Number of unique users.


### PR DESCRIPTION
Slightly changed return type of 2 member functions. **Checked thoroughly** to make sure internal compatibility still holds. Saved more memory space during initialization.